### PR TITLE
feat(CI): add publish image in the CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.yaml @mrpinkcat
+.yml @mrpinkcat

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ main ]
     paths: [ 'frontend/**', '.github/**' ]
+
+env:
+  DOCKERHUB_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/challenge-5a-s1-frontend
     
 jobs:
   eslint:
@@ -25,8 +28,9 @@ jobs:
         run: npm install eslint
       - name: Launch eslint
         run: npm run lint
+
   build:
-    needs: 
+    needs:
       - eslint
     runs-on: ubuntu-latest
     name: Build (frontend)
@@ -42,3 +46,39 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+
+  docker_build:
+    if: github.event_name == 'pull_request'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    name: Build image (frontend)
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build
+        run: docker build .
+
+  publish_image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    name: Publish image (frontend)
+    needs: 
+      - build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: "./frontend"
+          push: true
+          tags: ${{ env.DOCKERHUB_REPO }}:latest, ${{ env.DOCKERHUB_REPO }}:${{ github.sha }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
   "recommendations": [
-      "xdebug.php-debug",
-      "thenouillet.symfony-vscode",
-      "phproberto.vscode-php-getters-setters",
-      "bmewburn.vscode-intelephense-client",
+    "xdebug.php-debug",
+    "thenouillet.symfony-vscode",
+    "phproberto.vscode-php-getters-setters",
+    "bmewburn.vscode-intelephense-client",
+    "jasonnutter.vscode-codeowners"
   ]
 }

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Secret
 .env
+
+# image build
+image-build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:lts-alpine
+
+ARG VITE_API
+ENV VITE_API=$VITE_API
+
+# install git
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+# install simple http server for serving static content
+RUN npm install -g http-server
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm install
+
+# Copy app source code
+COPY . .
+
+# Build app
+RUN npm run build
+
+# Expose port and start application
+EXPOSE 8080
+CMD ["http-server", "-c-1", "--proxy", "http://localhost:8080?", "dist"]

--- a/frontend/deployment-front.yaml
+++ b/frontend/deployment-front.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend-deployment
+  namespace: challenge-5a-s1
+  labels:
+    app: react
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: react
+  template:
+    metadata:
+      labels:
+        app: react
+    spec:
+      containers:
+      - name: front
+        image: gatien1/challenge-5a-s1-frontend:latest
+        ports:
+        - containerPort: 8080
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-service
+  namespace: challenge-5a-s1
+spec:
+  type: NodePort
+  selector:
+    app: react
+  ports:
+  - protocol: TCP
+    port : 8888
+    targetPort: 8080
+    nodePort: 30000


### PR DESCRIPTION
Ajout d'un job de build de l'image docker dans la CI quand on est sur une branch de feature.

Lors du main sur merge, un job de CI push l'image sur le docker hub avec 2 tags:  `latest` et le sha du commit.

L'image du front peut etre retrouvé ici https://hub.docker.com/repository/docker/gatien1/challenge-5a-s1-frontend/general

![Capture d’écran 2023-10-20 à 19 18 47](https://github.com/ESGI-69/challenge-5A-S1/assets/13932200/fa361704-b553-4871-baab-9e227c129e79)

Prochaine étape : job de deployment sur le vps depuis l'image du docker hub